### PR TITLE
fix: change conceptual `owner` to a conceptual `output`

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -29,7 +29,8 @@ def on_sign(args: argparse.Namespace):
     (1) hash the file given with --file and save it as '<file>.sha256sum.txt';
     (2) print its hash as a QR code to sign with Krux (Sign > Message);
     (3) scan the signature QR code and save it (default '<file>.sig');
-    (4) scan the public key QR code and save it as a '<owner>.pem' certificate.
+    (4) scan the public key QR code and save it as a PEM certificate at the
+        path given with --pub-file (default 'pubkey.pem').
     """
     data = open_and_hash_file(args.file_to_sign)
     save_hashed_file(data, args.file_to_sign)
@@ -53,7 +54,7 @@ def on_sign(args: argparse.Namespace):
         is_normalized=args.is_normalized, is_gray_scale=args.is_gray_scale
     )
     create_public_key_certificate(
-        pubkey, uncompressed=args.uncompressed_pub_key, owner=args.file_owner
+        pubkey, uncompressed=args.uncompressed_pub_key, path=args.pub_file
     )
 
 

--- a/src/ksigner.py
+++ b/src/ksigner.py
@@ -94,10 +94,10 @@ signer.add_argument(
 
 signer.add_argument(
     "-o",
-    "--owner",
-    dest="file_owner",
-    help="the owner's name of public key certificate, i.e, the .pem file (default: 'pubkey')",
-    default="pubkey",
+    "--pub-file",
+    dest="pub_file",
+    help="path to save the public key PEM file (default: 'pubkey.pem')",
+    default="pubkey.pem",
 )
 
 signer.add_argument(

--- a/src/pemutils.py
+++ b/src/pemutils.py
@@ -18,11 +18,10 @@ log = logging.getLogger(__name__)
 
 
 def create_public_key_certificate(
-    pubkey: str, uncompressed: bool = False, owner: str = "pubkey"
+    pubkey: str, uncompressed: bool = False, path: str = "pubkey.pem"
 ):
     """
-    Build a PEM public key certificate from the hex `pubkey` and save it
-    as '<owner>.pem'.
+    Build a PEM public key certificate from the hex `pubkey` and save it to `path`.
     """
     prepend = (
         KSIGNER_UNCOMPRESSED_PUBKEY_PREPEND
@@ -42,7 +41,6 @@ def create_public_key_certificate(
     )
     log.debug("%s", pem)
 
-    pem_file = f"{owner}.pem"
-    log.debug("Saving public key file: %s", pem_file)
-    with open(pem_file, mode="w", encoding="utf-8") as file:
+    log.debug("Saving public key file: %s", path)
+    with open(path, mode="w", encoding="utf-8") as file:
         file.write(pem)


### PR DESCRIPTION
Before `krux-file-signer` was producing doubled extensions if someone pass owner as file, e.g., `-o <dir>/<file>.pem` -> `pubkey.pem.pem`. This commit proposes instead of a concept of owner, create (or overwrite) a referenceed `<dir>/<file>.pem`.