### PR TITLE
fix: flag `-u/--uncompressed`

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -45,6 +45,9 @@ example for setup of 'pre' public key strings above:
 KSIGNER_VERSION = "0.0.1-alpha-0"
 KSIGNER_UNCOMPRESSED_PUBKEY_PREPEND = "3056301006072A8648CE3D020106052B8104000A034200"
 KSIGNER_COMPRESSED_PUBKEY_PREPEND = "3036301006072A8648CE3D020106052B8104000A032200"
+
+# secp256k1 field prime, for recovering y from a compressed point (y^2 = x^3 + 7).
+KSIGNER_SECP256K1_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
 KSIGNER_CLI_DESCRIPTION = "".join(
     [
         "This python script is a tool to create air-gapped signatures of files using Krux. ",

--- a/src/pemutils.py
+++ b/src/pemutils.py
@@ -13,8 +13,29 @@ import logging
 
 from constants import KSIGNER_COMPRESSED_PUBKEY_PREPEND
 from constants import KSIGNER_UNCOMPRESSED_PUBKEY_PREPEND
+from constants import KSIGNER_SECP256K1_P
 
 log = logging.getLogger(__name__)
+
+
+def decompress_pubkey(compressed: bytes) -> bytes:
+    """
+    Recover 65-byte uncompressed SEC point from a 33-byte compressed key.
+    """
+    # Krux only a compressed public key, so we must rebuild y from secp256k1 equation
+    if len(compressed) != 33 or compressed[0] not in (0x02, 0x03):
+        raise ValueError("not a compressed SEC public key (need 33 bytes, 0x02/0x03)")
+
+    prefix = compressed[0]
+    x = int.from_bytes(compressed[1:], "big")
+    y_2 = (pow(x, 3, KSIGNER_SECP256K1_P) + 7) % KSIGNER_SECP256K1_P
+    y = pow(y_2, (KSIGNER_SECP256K1_P + 1) // 4, KSIGNER_SECP256K1_P)
+    if (y * y) % KSIGNER_SECP256K1_P != y_2:
+        raise ValueError("invalid compressed pubkey")
+    if (y & 1) != (prefix & 1):
+        y = KSIGNER_SECP256K1_P - y
+
+    return b"\x04" + x.to_bytes(32, "big") + y.to_bytes(32, "big")
 
 
 def create_public_key_certificate(
@@ -33,8 +54,11 @@ def create_public_key_certificate(
         "uncompressed" if uncompressed else "compressed",
     )
 
-    # prepend + pubkey is a DER (binary) key; a PEM body is just its base64.
-    der_bytes = bytes.fromhex(f"{prepend}{pubkey}")
+    key_bytes = bytes.fromhex(pubkey)
+    if uncompressed and len(key_bytes) == 33:
+        key_bytes = decompress_pubkey(key_bytes)
+
+    der_bytes = bytes.fromhex(prepend) + key_bytes
     pem_body = base64.b64encode(der_bytes).decode("ascii")
     pem = "\n".join(
         ["-----BEGIN PUBLIC KEY-----", pem_body, "-----END PUBLIC KEY-----"]


### PR DESCRIPTION
Before this commit when the `-u` is provided on `sign` command, it produced invalid verification due to not reconstruct uncompressed key (prefix 04) from compressed one (02/03) and would give sensation that firmware is the issue. This commit fix this.

How to reproduce:

**Compressed keys**

Power on krux and load some key. Then:

```bash
$> uv run poe sign -f README.md
Poe => python src/ksigner.py sign -f README.md
...
```

This will produce the `README.md.{sha256.tx,sig} and pubkey.pem`. Check the size with `cat`:
Should be something like:

```bash
$> cat pubkey.pem 
-----BEGIN PUBLIC KEY-----
MDYwEAYHKoZIzj0CAQYFK4EEAAoDIgACB5jsRnBQaWpX1V+drUfen5sQjx8YeEkdMyR67bh1LGw=
-----END PUBLIC KEY----
```

Also verify with:

```bash
uv run poe verify -f README.md -p pubkey.pem -s README.md.sig
```

**Uncompressed keys**

```bash
$> uv run poe sign -f README.md --uncompressed
Poe => python src/ksigner.py sign -f README.md --uncompressed
...
```

This will produce the `README.md.{sha256.tx,sig} and pubkey.pem`. Check the size with `cat`. It should be bigger:

```bash
$> cat pubkey.pem
-----BEGIN PUBLIC KEY-----
MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEB5jsRnBQaWpX1V+drUfen5sQjx8YeEkdMyR67bh1LGzzs+aaa+xt/86ZC/3G5rUeRrjhwAoCHPympz+PuG1myg==
-----END PUBLIC KEY-----
```

 Also verify with:

```bash
uv run poe verify -f README.md -p pubkey.pem -s README.md.sig
```